### PR TITLE
shim to enable the xx-testing locale

### DIFF
--- a/product_details/__init__.py
+++ b/product_details/__init__.py
@@ -52,6 +52,8 @@ class ProductDetails(object):
                 self.json_data[name] = json.load(open(path))
 
     def __getattr__(self, key):
+        if key == 'languages':
+            self.json_data[key]['xx-testing'] = {'native': 'Testing'}
         """Catch-all for access to JSON files."""
         try:
             return self.json_data[key]


### PR DESCRIPTION
l10n already has an xx-testing locale registered in verbatim. this shim intercepts requests for languages and adds the xx-testing locale so a requesting django app (i.e., on dev or staging) can asks for the 'xx-testing' language. 

combining this with settings.DEV_LANGUAGES and a locale/xx_testing directory lets a developer create a testing locale with a tool like podebug.