### PR TITLE
Support memcache by using django's caching framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,13 @@ Add ``product_details`` to your ``INSTALLED_APPS`` to enable the management
 commands.
 
 ### Configuration
-No configuration should be necessary. However, you can add and alter the
-following settings to your ``settings.py`` file if you disagree with the
-defaults:
+
+No configuration should be necessary. This uses Django's [caching
+framework][caching] to store the results. If left unconfigured, it
+will use a dummy cache that just stores it in memory.
+
+If needed, you can add and alter the following settings to your
+``settings.py`` file if you disagree with the defaults:
 
 * ``PROD_DETAILS_URL`` defaults to the JSON directory on the Mozilla SVN
   server. If you have a secondary mirror at hand, or you want this tool to
@@ -67,6 +71,20 @@ defaults:
   be writable by the user that'll execute the management command, and readable
   by the user running the Django project. Defaults to:
   ``.../install_dir_of_this_app/product_details/json/``
+* ``PROD_DETAILS_TTL`` is the time-to-live to set on the cache entry (defaults to 
+  1 day).
+
+It is recommended to use memcache for caching, and you can configure
+it with the following in your ``settings.py``:
+
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+            'LOCATION': '127.0.0.1:11211',
+        }
+    }
+
+[caching]: https://docs.djangoproject.com/en/dev/topics/cache/?from=olddocs
 
 ### Updating the feed
 To update the data, execute this:

--- a/product_details/__init__.py
+++ b/product_details/__init__.py
@@ -9,6 +9,8 @@ import json
 import logging
 import os
 
+from django.core.cache import cache
+
 # During `pip install`, we need this to pass even without Django present.
 try:
     from django.conf import settings
@@ -18,7 +20,7 @@ except ImportError:
 from product_details import settings_defaults
 
 
-VERSION = (0, 5)
+VERSION = (0, 6)
 __version__ = '.'.join(map(str, VERSION))
 __all__ = ['VERSION', '__version__', 'product_details', 'version_compare']
 
@@ -50,15 +52,22 @@ class ProductDetails(object):
             if filename.endswith('.json'):
                 name = os.path.splitext(filename)[0]
                 path = os.path.join(json_dir, filename)
-                self.json_data[name] = json.load(open(path))
+                self._set_data(name, json.load(open(path)))
 
     def __getattr__(self, key):
         """Catch-all for access to JSON files."""
-        try:
-            return self.json_data[key]
-        except KeyError:
+        data = self._get_data(key)
+        if data is None:
             log.warn('Requested product details file %s not found!' % key)
-            return collections.defaultdict(lambda: None)
+            data = collections.defaultdict(lambda: None)
+        return data
+
+    def _set_data(self, key, data):
+        cache.set('product-details-%s' % key, data,
+                  settings_fallback('PROD_DETAILS_TTL'))
+
+    def _get_data(self, key, default=None):
+        return cache.get('product-details-%s' % key) or None
 
     @property
     def last_update(self):
@@ -91,12 +100,12 @@ class ProductDetails(object):
             key = 'regions/%s' % l
             path = os.path.join(settings_fallback('PROD_DETAILS_DIR'),
                                 'regions', '%s.json' % l)
-            if self.json_data.get(key):
-                return self.json_data.get(key)
+            if self._get_data(key):
+                return self._get_data(key)
             if os.path.exists(path):
                 with codecs.open(path, encoding='utf8') as fd:
-                    self.json_data[key] = json.load(fd)
-                    return self.json_data[key]
+                    self._set_data(key, json.load(fd))
+                    return self._get_data(key)
 
         raise IOError('Unable to load region data for %s or en-US' % locale)
 

--- a/product_details/settings_defaults.py
+++ b/product_details/settings_defaults.py
@@ -9,5 +9,8 @@ PROD_DETAILS_URL = 'http://svn.mozilla.org/libs/product-details/json/'
 # Target dir to drop JSON files into (must be writable)
 PROD_DETAILS_DIR = os.path.join(os.path.dirname(__file__), 'json')
 
+# Cache for 1 day by default
+PROD_DETAILS_TTL = 60 * 60 * 24
+
 # log level.
 LOG_LEVEL = logging.WARNING


### PR DESCRIPTION
This uses django's caching framework instead of setting the data straight into memory. We can control how this data is persisted.

This is necessary for mozilla.org because we need to refresh it every 15 minutes. With how it is currently, we would need to restart all the wsgi process which incurs too much of a performance hit.