### PR TITLE
fix django 1.5 style settings import

### DIFF
--- a/product_details/__init__.py
+++ b/product_details/__init__.py
@@ -9,6 +9,8 @@ import json
 import logging
 import os
 
+from django.core.exceptions import ImproperlyConfigured
+
 # During `pip install`, we need this to pass even without Django present.
 try:
     from django.conf import settings
@@ -34,7 +36,7 @@ def settings_fallback(key):
     """Grab user-defined settings, or fall back to default."""
     try:
         return getattr(settings, key)
-    except (AttributeError, ImportError):
+    except (AttributeError, ImportError, ImproperlyConfigured):
         return getattr(settings_defaults, key)
 
 


### PR DESCRIPTION
Django 1.5 will happily let you import settings, then will later blow up when you try to access it with `django.core.exceptions.ImproperlyConfigured` so this library is unable to be installed on Django 1.5 without this patch.
