### PR TITLE
Fix problem with json when installed via pip.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 include README.md
+recursive-include product_details/json *


### PR DESCRIPTION
Currently the json folder doesn't get created, which causes a file not found when it looks for the product detail location.

This will ensure the folder is created during a pip install.
