### PR TITLE
Fix OSError: No such file or directory

### DIFF
--- a/product_details/__init__.py
+++ b/product_details/__init__.py
@@ -46,11 +46,12 @@ class ProductDetails(object):
 
         json_dir = settings_fallback('PROD_DETAILS_DIR')
 
-        for filename in os.listdir(json_dir):
-            if filename.endswith('.json'):
-                name = os.path.splitext(filename)[0]
-                path = os.path.join(json_dir, filename)
-                self.json_data[name] = json.load(open(path))
+        if os.path.exists(json_dir):
+            for filename in os.listdir(json_dir):
+                if filename.endswith('.json'):
+                    name = os.path.splitext(filename)[0]
+                    path = os.path.join(json_dir, filename)
+                    self.json_data[name] = json.load(open(path))
 
     def __getattr__(self, key):
         """Catch-all for access to JSON files."""


### PR DESCRIPTION
If you import product_details, in `__init__.py` it goes to build a
ProductDetails instance. If the json_dir doesn't exist, that fails with
an OSError.

That's problematic because then it becomes difficult in some situations
to run `./manage.py update_product_details`.

This fixes that so that it checks to see if the directory exists first.

Fixes #34 

r?
