### PR TITLE
Avoid using a mutable type as a class attribute.

### DIFF
--- a/product_details/__init__.py
+++ b/product_details/__init__.py
@@ -19,7 +19,7 @@ class MissingJSONData(IOError):
     pass
 
 
-__version__ = '0.6'
+__version__ = '0.7'
 __all__ = ['__version__', 'product_details', 'version_compare']
 
 log = logging.getLogger('product_details')
@@ -39,10 +39,9 @@ class ProductDetails(object):
     Main product details class. Implements the JSON files' content as
     attributes, e.g.: product_details.firefox_version_history .
     """
-    json_data = {}
-
     def __init__(self):
         """Load JSON files and keep them in memory."""
+        self.json_data = {}
 
         json_dir = settings_fallback('PROD_DETAILS_DIR')
 


### PR DESCRIPTION
This caused much confusion in bedrock as subclasses were
getting strange data in tests when other subclasses were
instantiated. This was because all of the class instances
were using the same dict for data storage.