### PR TITLE
Fix #49: fix product_details.last_update

### DIFF
--- a/product_details/__init__.py
+++ b/product_details/__init__.py
@@ -51,7 +51,7 @@ class ProductDetails(object):
     @property
     def last_update(self):
         """Return the last-updated date, if it exists."""
-        return self._storage.last_updated('/')
+        return self._storage.last_modified_datetime('/')
 
     def get_regions(self, locale):
         """Loads regions json file into memory, but only as needed."""

--- a/product_details/storage.py
+++ b/product_details/storage.py
@@ -5,6 +5,7 @@ import os
 import os.path
 import tempfile
 import shutil
+from datetime import datetime
 
 from product_details import settings_defaults
 from product_details.models import ProductDetailsFile
@@ -43,6 +44,14 @@ class ProductDetailsStorage(object):
         Return the last-modified value for the requested file name.
         """
         raise NotImplementedError()
+
+    def last_modified_datetime(self, name):
+        fmt = '%a, %d %b %Y %H:%M:%S %Z'
+        try:
+            return datetime.strptime(self.last_modified(name), fmt)
+        except (ValueError, TypeError):
+            # bad date string format or None
+            return None
 
     def content(self, name):
         """


### PR DESCRIPTION
Was calling a non-existant method of the storage class,
thus raising an exception, thus returning a defaultdict.
Now returns the expected datetime object again.