### PR TITLE
Use requests for fetching remote data.

### DIFF
--- a/product_details/__init__.py
+++ b/product_details/__init__.py
@@ -11,7 +11,7 @@ class MissingJSONData(IOError):
 
 
 __version__ = '0.9'
-__all__ = ['__version__', 'product_details']
+__all__ = ['__version__', 'product_details', 'version_compare']
 
 log = logging.getLogger('product_details')
 log.setLevel(settings_fallback('LOG_LEVEL'))

--- a/product_details/version_compare/__init__.py
+++ b/product_details/version_compare/__init__.py
@@ -15,8 +15,8 @@ _version_re = re.compile(
         (?P<alpha>[a|b]?)   # alpha/beta
         (?P<alpha_ver>\d*)  # alpha/beta version
         (?P<pre>pre)?       # pre release
-        (?P<pre_ver>\d)?    # pre release version""",
-    re.VERBOSE)
+        (?P<pre_ver>\d)?    # pre release version
+    """, re.VERBOSE)
 
 
 @total_ordering
@@ -86,7 +86,8 @@ def version_list(releases, key=None, reverse=True, hide_below='0.0',
     filter is a function that maps Version objects to "include? True/False".
     """
     if not key:
-        key = lambda x: x[1]  # Default: Sort by release date.
+        def key(x):
+            return x[1]  # Default: Sort by release date.
 
     lowest = Version(hide_below)
     versions = []

--- a/product_details/version_compare/utils.py
+++ b/product_details/version_compare/utils.py
@@ -6,7 +6,8 @@ def uniquifier(seq, key=None):
     Borrowed in part from http://www.peterbe.com/plog/uniqifiers-benchmark
     """
     if key is None:
-        key = lambda x: x
+        def key(x):
+            return x
 
     def finder(seq):
         seen = {}

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -2,3 +2,4 @@ Django>=1.8,<1.9
 setuptools>=0.9
 wheel>=0.21
 twine
+requests>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 tox
 wheel
 twine
+responses

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    install_requires=['Django>=1.7'],
+    install_requires=['Django>=1.7', 'requests>=2.0.0'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,73 @@
+from django.core.management import call_command
+from django.test.testcases import TestCase
+
+import responses
+from mock import patch
+from nose.tools import eq_
+
+from product_details.storage import ProductDetailsStorage
+
+
+class MockStorage(ProductDetailsStorage):
+    """In-memory mock storage for testing."""
+
+    def __init__(self, *args, **kwargs):
+        super(MockStorage, self).__init__(*args, **kwargs)
+        self.documents = {}
+
+    def last_modified(self, name):
+        doc = self.documents.get(name)
+        if doc:
+            return doc['last_modified']
+
+        return None
+
+    def content(self, name):
+        doc = self.documents.get(name)
+        if doc:
+            return doc['content']
+
+        return None
+
+    def update(self, name, content, last_modified):
+        self.documents[name] = {'content': content, 'last_modified': last_modified}
+        self.delete_cache(name)
+
+
+class UpdateProductDetailsTests(TestCase):
+    def setUp(self):
+        # Mock out storage to avoid filesystem writes.
+        self.storage = MockStorage(json_dir='/fake')
+        storage_patch = patch(
+            'product_details.management.commands.update_product_details.STORAGE_CLASS',
+            return_value=self.storage
+        )
+        storage_patch.start()
+        self.addCleanup(storage_patch.stop)
+
+    @responses.activate
+    def test_run(self):
+        responses.add(
+            responses.GET,
+            'http://example.com',
+            body='<a href="test.json">test.json</a>'
+        )
+        responses.add(
+            responses.GET,
+            'http://example.com/regions/',
+            body=''
+        )
+        responses.add(
+            responses.GET,
+            'http://example.com/test.json',
+            body='{"foo": "bar"}',
+            adding_headers={'Last-Modified': 'Sat, 01 Jan 2000 00:00:00 GMT'}
+        )
+
+        with self.settings(PROD_DETAILS_URL='http://example.com/'):
+            call_command('update_product_details')
+
+        eq_(self.storage.documents['test.json'], {
+            'content': '{"foo": "bar"}',
+            'last_modified': 'Sat, 01 Jan 2000 00:00:00 GMT',
+        })

--- a/tox.ini
+++ b/tox.ini
@@ -11,11 +11,13 @@ deps =
     dj17: Django>=1.7,<1.8
     dj18: Django>=1.8,<1.9
     dj19: Django>=1.9,<1.10
+    requests==2.0.0
     mock==1.0.1
     nose==1.3.6
+    responses==0.5.0
 
 [testenv:flake8]
-deps = flake8
+deps = flake8==2.5.1
 commands = flake8 product_details tests
 
 [flake8]


### PR DESCRIPTION
The existing stdlib use failed on Python 3 due to the returned data being
a bytes object instead of a string that json.loads could accept. Requests
handles the decoding for us!

@pmclanahan r? I also added a very small test of the management command, we could add more tests later but this basically solves all my own needs.