### PR TITLE
Fix Django 1.9/1.10 deprecation notices.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,14 @@
 sudo: false
 language: python
 env:
-  - TOXENV=py27-dj17
   - TOXENV=py27-dj18
-  - TOXENV=py33-dj17
   - TOXENV=py33-dj18
-  - TOXENV=py34-dj17
   - TOXENV=py34-dj18
-  - TOXENV=pypy-dj17
+  - TOXENV=py35-dj18
   - TOXENV=pypy-dj18
   - TOXENV=py27-dj19
   - TOXENV=py34-dj19
   - TOXENV=py35-dj19
-  - TOXENV=py35-dj18
   - TOXENV=flake8
 install:
   - travis_retry pip install tox

--- a/product_details/management/commands/update_product_details.py
+++ b/product_details/management/commands/update_product_details.py
@@ -1,9 +1,8 @@
 import logging
 import re
-from optparse import make_option
 
 from django.utils.six.moves.urllib.parse import urljoin
-from django.core.management.base import NoArgsCommand, CommandError
+from django.core.management.base import BaseCommand, CommandError
 from django.utils.module_loading import import_string
 
 import requests
@@ -18,18 +17,9 @@ log.setLevel(settings_fallback('LOG_LEVEL'))
 STORAGE_CLASS = import_string(settings_fallback('PROD_DETAILS_STORAGE'))
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = 'Update Mozilla product details off SVN.'
     requires_model_validation = False
-    option_list = NoArgsCommand.option_list + (
-        make_option('-f', '--force', action='store_true', dest='force',
-                    default=False, help=(
-                        'Download product details even if they have not been '
-                        'updated since the last fetch.')),
-        make_option('-q', '--quiet', action='store_true', dest='quiet',
-                    default=False, help=(
-                        'If no error occurs, swallow all output.')),
-    )
 
     def __init__(self, *args, **kwargs):
         # some settings
@@ -39,7 +29,17 @@ class Command(NoArgsCommand):
 
         super(Command, self).__init__(*args, **kwargs)
 
-    def handle_noargs(self, **options):
+    def add_arguments(self, parser):
+        parser.add_argument('-f', '--force', action='store_true', dest='force',
+                            default=False, help=(
+                                'Download product details even if they have '
+                                'not been updated since the last fetch.'))
+
+        parser.add_argument('-q', '--quiet', action='store_true', dest='quiet',
+                            default=False, help=(
+                                'If no error occurs, swallow all output.')),
+
+    def handle(self, *args, **options):
         self.options = options
 
         # Should we be quiet?

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    install_requires=['Django>=1.7', 'requests>=2.0.0'],
+    install_requires=['Django>=1.8', 'requests>=2.0.0'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,13 @@
 [tox]
 args_are_paths = false
 skip_missing_interpreters = true
-envlist = py{27,33,34,py}-dj{17,18},py{27,34,35}-dj19,py35-dj18,flake8
+envlist = py{27,33,34,35,py}-dj18,py{27,34,35}-dj19,flake8
 
 [testenv]
 usedevelop = true
 pip_pre = true
 commands = ./runtests.py
 deps =
-    dj17: Django>=1.7,<1.8
     dj18: Django>=1.8,<1.9
     dj19: Django>=1.9,<1.10
     requests==2.0.0


### PR DESCRIPTION
Fixes some issues with features going away in Django 1.10. As a result, this also bumps us up to Django 1.8 as the minimum Django version supported.

This depends on #54. @pmclanahan r?