### PR TITLE
Fix #62: Lazily initialize storage.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -185,6 +185,10 @@ Caveats / Known Issues
                return [(lang.lower(), product_details.languages[lang]['native'])
                        for lang in MY_LANGUAGES]
        LANGUAGES = lazy(LazyLangs, list)()
+3. Using product_details before Django has finished initializing, e.g. in your
+   app's ``__init__.py`` it may raise a
+   ``django.core.exceptions.AppRegistryNotReady`` exception. The lazy loading
+   example from above should help you overcome this issue.
 
 Development
 -----------

--- a/product_details/__init__.py
+++ b/product_details/__init__.py
@@ -26,9 +26,20 @@ class ProductDetails(object):
 
     def __init__(self, json_dir=None, cache_name=None, cache_timeout=None,
                  storage_class=None):
-        storage_class = import_string(storage_class or settings_fallback('PROD_DETAILS_STORAGE'))
-        self._storage = storage_class(cache_name=cache_name, cache_timeout=cache_timeout,
-                                      json_dir=json_dir)
+        self._storage_class = import_string(storage_class or settings_fallback('PROD_DETAILS_STORAGE'))
+        self._json_dir = json_dir
+        self._cache_name = cache_name
+        self._cache_timeout = cache_timeout
+        self._real_storage = None
+
+    @property
+    def _storage(self):
+        if not self._real_storage:
+            self._real_storage = self._storage_class(
+                cache_name=self._cache_name,
+                cache_timeout=self._cache_timeout,
+                json_dir=self._json_dir)
+        return self._real_storage
 
     def __getattr__(self, key):
         data = self._storage.data('{0}.json'.format(key))

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -199,7 +199,7 @@ class PDDatabaseStorageTests(PDStorageClassMixin, TestCase):
         self.assertEqual(len(regions_data), 2)
 
 
-@patch('product_details.product_details._storage', Mock())
+@patch('product_details.product_details._real_storage', Mock())
 class ProductDetailsTests(TestCase):
     pd = product_details.product_details
 


### PR DESCRIPTION
In Django versions >1.9 initializing storage on application load raises
django.core.exceptions.AppRegistryNotReady when using PDDatabaseStorage storage
class.

This patch makes the initialization happen on first request to product details.
Requests should happen after Django has finished initializing.