### PR TITLE
Migration

### DIFF
--- a/product_details/migrations/0001_initial.py
+++ b/product_details/migrations/0001_initial.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('name', models.CharField(max_length=250, serialize=False, primary_key=True)),
                 ('content', models.TextField(blank=True)),
-                ('last_modified', models.CharField(help_text=b'Value of Last-Modified HTTP header',
+                ('last_modified', models.CharField(help_text='Value of Last-Modified HTTP header',
                                                    max_length=50)),
             ],
             options={


### PR DESCRIPTION
Fixes #68 

Here's how I tested this:

I created a brand new virtualenv (python 3.7) and `pip install Django django-mozilla-product-details`. Then I added `product_details` to the `INSTALLED_APPS` and ran `./manage.py migrate`. 

```
▶ ./manage.py migrate
Operations to perform:
  Apply all migrations: admin, auth, contenttypes, product_details, sessions
Running migrations:
  Applying product_details.0001_initial... OK
  Applying product_details.0002_auto_20151006_1348... OK
```

And it still wants to create another migration:
```
▶ ./manage.py makemigrations --check
Migrations for 'product_details':
  /private/tmp/dpd/lib/python3.7/site-packages/product_details/migrations/0003_auto_20190301_2016.py
    - Alter field last_modified on productdetailsfile
```

So I delete `/private/tmp/dpd/lib/python3.7/site-packages/product_details/migrations/0003_auto_20190301_2016.py` and edit `/private/tmp/dpd/lib/python3.7/site-packages/product_details/migrations/0001_initial.py` and all I did was remove the `b` for a binary string. 

Now:

```
▶ ./manage.py makemigrations --check
No changes detected
```

So yay! It works. 