### PR TITLE
Upgrade Django to 1.11

### DIFF
--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,4 +1,4 @@
-Django>=1.8,<1.9
+Django>=1.11.19
 setuptools>=0.9
 wheel>=0.21
 twine


### PR DESCRIPTION
* Mitigate [CVE-2019-6975](https://github.com/advisories/GHSA-wh4h-v3f2-r2pp) which allows Uncontrolled Memory Consumption via a malicious attacker-supplied value to the `django.utils.numberformat.format()` function. 
* Mitigate [CVE-2019-3498](https://github.com/advisories/GHSA-337x-4q8g-prc5). Improper Neutralization of Special Elements in Output Used by a Downstream Component issue exists in `django.views.defaults.page_not_found()`, leading to content spoofing (in a 404 error page) if a user fails to recognize that a crafted URL has malicious content.

Though `django-product-details` doesn't use the `django.utils.numberformat.format()` or `django.views.defaults.page_not_found()` functions, updating Django would prevent these vulnerabilities if the code does end up using them in the future.

If django-product-details won't work with Django newer than 1.9 then we can close and not merge this PR and I can mark these vulnerabilities as not applicable with the existing code.