### PR TITLE
Improve GH Actions configuration + tox setup; drop PyPy tests; support 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,26 +1,82 @@
 name: "CI" # Note that this name appears in the README's badge
 on: [push]
 jobs:
-  build:
+  build-cpython:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version:
+          # CPython
           - "3.7"
           - "3.8"
           - "3.9"
-          - "pypy-3.7"
-          - "pypy-3.8"
-    name: Python ${{ matrix.python-version }} in use
+          - "3.10"
+        django-tox-env:
+          - "django22"
+          - "django32"
+          - "django40"
+        exclude:
+          # We don't want every combination of the above, as some are not compatible
+          - python-version: "3.6"
+            django-tox-env: "django40"
+
+          - python-version: "3.7"
+            django-tox-env: "django40"
+
+          - python-version: "pypy-3.7"
+            django-tox-env: "django40"
+
+          - python-version: "3.10"
+            django-tox-env: "django22"
+
+    name: Python ${{ matrix.python-version }} + ${{ matrix.django-tox-env }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          # Note that all envs will have the default version of Python available,
-          # too. This is 3.8 at time of writing.
           python-version: ${{ matrix.python-version }}
-          architecture: "x64" # optional x64 (default) or x86.
       - name: Install tox
         run: pip install tox
       - name: Run tox
-        run: tox
+        run: tox -e py${{ matrix.python-version }}-${{ matrix.django-tox-env }} --skip-missing-interpreter=false
+
+  # DISABLED: needs a viable way to upgrade pypy-bundled sqlite to be 3.8.3, not 3.7.17, else Django won't start
+  # build-pypy:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       python-version:
+  #         - "pypy-3.7"
+  #         - "pypy-3.8"
+  #       django-tox-env:
+  #         - "django22"
+  #         - "django32"
+  #         - "django40"
+  #       exclude:
+  #         # We don't want every combination of the above, as some are not compatible
+  #         - python-version: "pypy-3.7"
+  #           django-tox-env: "django40"
+
+  #   name: Python ${{ matrix.python-version }} + ${{ matrix.django-tox-env }}
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-python@v2
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
+  #     - name: Install tox
+  #       run: pip install tox
+  #     - name: Run tox
+  #       run: tox -e ${{ matrix.python-version }}-${{ matrix.django-tox-env }} --skip-missing-interpreter=false
+
+  lint:
+    runs-on: ubuntu-latest
+    name: Flake 8
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install test requirements
+        run: pip install tox flake8
+      - name: Run tox
+        run: tox -e py3.9-flake8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,6 @@ jobs:
           - python-version: "3.7"
             django-tox-env: "django40"
 
-          - python-version: "pypy-3.7"
-            django-tox-env: "django40"
-
           - python-version: "3.10"
             django-tox-env: "django22"
 
@@ -39,34 +36,6 @@ jobs:
         run: pip install tox
       - name: Run tox
         run: tox -e py${{ matrix.python-version }}-${{ matrix.django-tox-env }} --skip-missing-interpreter=false
-
-  # DISABLED: needs a viable way to upgrade pypy-bundled sqlite to be 3.8.3, not 3.7.17, else Django won't start
-  # build-pypy:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       python-version:
-  #         - "pypy-3.7"
-  #         - "pypy-3.8"
-  #       django-tox-env:
-  #         - "django22"
-  #         - "django32"
-  #         - "django40"
-  #       exclude:
-  #         # We don't want every combination of the above, as some are not compatible
-  #         - python-version: "pypy-3.7"
-  #           django-tox-env: "django40"
-
-  #   name: Python ${{ matrix.python-version }} + ${{ matrix.django-tox-env }}
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-python@v2
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #     - name: Install tox
-  #       run: pip install tox
-  #     - name: Run tox
-  #       run: tox -e ${{ matrix.python-version }}-${{ matrix.django-tox-env }} --skip-missing-interpreter=false
 
   lint:
     runs-on: ubuntu-latest

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -6,11 +6,6 @@ envlist =
     {py3.7,py3.8,py3.9}-django22
     {py3.7,py3.8,py3.9,py3.10}-django32
     {py3.8,py3.9,py3.10}-django40
-    ; DISABLED: needs a viable way to upgrade pypy-bundled sqlite to be 3.8.3, 
-    ; not 3.7.17, else Django won't start
-    ; {pypy3.7,pypy-3.8}-django22
-    ; {pypy-3.7,pypy-3.8}-django32
-    ; {pypy-3.8}-django40
 
 [testenv]
 usedevelop = true
@@ -30,11 +25,6 @@ basepython =
     py3.9: python3.9
     py3.8: python3.8
     py3.7: python3.7
-
-    ; DISABLED: needs a viable way to upgrade pypy-bundled sqlite to be 3.8.3, 
-    ; not 3.7.17, else Django won't start
-    ; pypy-3.7: pypy3.7
-    ; pypy-3.8: pypy3.8
 
 [testenv:py3.9-flake8]
 deps = flake8 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands = ./runtests.py
 deps =
     django22: Django>=2.2,<2.3
     django32: Django>=3.2,<4.0
-    django40: Django>=4.0,<5.0
+    django40: Django>=4.0,<4.1
 
     nose==1.3.7
     mock==4.0.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,42 @@
 [tox]
 args_are_paths = false
 skip_missing_interpreters = true
-envlist = py{37,38,39,py3}-dj22, \
-          py{37,38,39,py3}-dj32, \
-          flake8
+envlist = 
+    py3.9-flake8
+    {py3.7,py3.8,py3.9}-django22
+    {py3.7,py3.8,py3.9,py3.10}-django32
+    {py3.8,py3.9,py3.10}-django40
+    ; DISABLED: needs a viable way to upgrade pypy-bundled sqlite to be 3.8.3, 
+    ; not 3.7.17, else Django won't start
+    ; {pypy3.7,pypy-3.8}-django22
+    ; {pypy-3.7,pypy-3.8}-django32
+    ; {pypy-3.8}-django40
 
 [testenv]
 usedevelop = true
 pip_pre = true
 commands = ./runtests.py
 deps =
-    dj22: Django>=2.2,<2.3
-    dj32: Django>=3.2,<4.0
+    django22: Django>=2.2,<2.3
+    django32: Django>=3.2,<4.0
+    django40: Django>=4.0,<5.0
 
     nose==1.3.7
     mock==4.0.3
     responses==0.15.0
     requests==2.26.0
+basepython =
+    py3.10: python3.10
+    py3.9: python3.9
+    py3.8: python3.8
+    py3.7: python3.7
 
-[testenv:flake8]
+    ; DISABLED: needs a viable way to upgrade pypy-bundled sqlite to be 3.8.3, 
+    ; not 3.7.17, else Django won't start
+    ; pypy-3.7: pypy3.7
+    ; pypy-3.8: pypy3.8
+
+[testenv:py3.9-flake8]
 deps = flake8 
 commands = flake8 product_details tests
 


### PR DESCRIPTION
This changeset cleans up the matrix strategy used in the GH action to only run
combinations we know are viable. This is more efficient and explicit.

Python 3.10 was added as a test CPython and seems to work fine.

Work towards the above changes also resulted in the PyPy tests failing, so
attempts were made to re-enable these, but it turns out that since Django 2.2,
the version of sqlite bundled inside PyPy has needed upgrading to be compatible
with it (https://docs.djangoproject.com/en/4.0/releases/2.2/#miscellaneous).
For now, PyPy tests have been disabled, following some time spent trying to
patch the version of sqlite. Hopefully we'll circle back to this with a solution.

Note: it looks like PyPy [_used_ to work](https://github.com/mozilla/django-product-details/actions/runs/1774203155), which makes it all the more puzzling that it's stopped working. (Or it was a false positive, somehow)

The tox coverage was broadened to Python 3.10, too.