### PR TITLE
Update Django and Python versions in test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,18 +17,16 @@ jobs:
           - "3.11"
         django-tox-env:
           - "django32"
-          - "django40"
           - "django42"
-          - "django50"
-        exclude:
-          # We don't want every combination of the above, as some are not compatible
+          - "django51"
+          - "django52"
+        exclude: # We don't want every combination of the above, as some are not compatible
           - python-version: "3.11"
             django-tox-env: "django32"
-          - python-version: "3.11"
-            django-tox-env: "django40"
           - python-version: "3.9"
-            django-tox-env: "django50"
-
+            django-tox-env: "django51"
+          - python-version: "3.9"
+            django-tox-env: "django52"
     name: Python ${{ matrix.python-version }} + ${{ matrix.django-tox-env }}
     steps:
       - uses: actions/checkout@v4
@@ -42,14 +40,14 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    name: Flake 8
+    name: Flake8
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
-      - name: Install test requirements
-        run: pip install tox flake8
+          python-version: "3.9"
+      - name: Install tox
+        run: pip install tox
       - name: Run tox
         run: tox -e py3.9-flake8
 
@@ -64,8 +62,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
-      - name: Install lightest dependencies for successful packaging
+          python-version: "3.9"
+      - name: Install packaging dependencies
         run: pip install Django requests build
       - name: Ensure the latest product-details json files are pulled in
         run: python updatejson.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
             django-tox-env: "django52"
     name: Python ${{ matrix.python-version }} + ${{ matrix.django-tox-env }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tox
@@ -42,8 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Flake8
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.9"
       - name: Install tox
@@ -59,8 +59,8 @@ jobs:
       - lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.9"
       - name: Install packaging dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,25 +12,22 @@ jobs:
     strategy:
       matrix:
         python-version:
-          # CPython
-          - "3.7"
-          - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
         django-tox-env:
-          - "django22"
           - "django32"
           - "django40"
+          - "django42"
+          - "django50"
         exclude:
           # We don't want every combination of the above, as some are not compatible
-          - python-version: "3.6"
+          - python-version: "3.11"
+            django-tox-env: "django32"
+          - python-version: "3.11"
             django-tox-env: "django40"
-
-          - python-version: "3.7"
-            django-tox-env: "django40"
-
-          - python-version: "3.10"
-            django-tox-env: "django22"
+          - python-version: "3.9"
+            django-tox-env: "django50"
 
     name: Python ${{ matrix.python-version }} + ${{ matrix.django-tox-env }}
     steps:

--- a/README.rst
+++ b/README.rst
@@ -214,9 +214,9 @@ Releasing
 1. Update the version number in ``product_details/__init__.py``.
 2. Add an entry to the change log in the README file.
 3. Tag the commit where you changed the above with the version number: e.g. ``1.0.4``.
-4. Push the commit and tag to the github repo.
+4. Push the commit and tag to the GitHub repo.
 5. Create a new GitHub release, selecting the tag you just pushed to specify the commit. Hit Publish.
-6. Github will build and release the package to PyPI. Monitor the progress via the Actions tab.
+6. GitHub will build and release the package to PyPI. Monitor the progress via the Actions tab.
 
 Note, if you need to manually build a release on your local machine, be sure
 to run ``python updatejson.py`` before you run ``python -m build .`` so that the

--- a/README.rst
+++ b/README.rst
@@ -196,7 +196,7 @@ Development
 Patches are welcome.
 
 To run tests, install ``tox`` and run ``tox`` from the project root.
-This will run the tests in Python 3.7, 3.8 and 3.9 against
+This will run the tests in Python 3.9, 3.10 and 3.11 against
 various appropriate Django versions. If you don't have ``tox`` and/or all the
 versions of Python available, install ``nose``, ``mock``, ``requests``,
 ``responses`` and ``Django`` (see ``tox.ini``'s ``deps``) and run the

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,9 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    install_requires=["Django>=2.2", "requests>=2.21.0"],
+    install_requires=["Django>=3.2", "requests>=2.21.0"],
     classifiers=[
-        "Development Status :: 4 - Beta",
+        "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
         "Environment :: Web Environment :: Mozilla",
         "Framework :: Django",
@@ -37,10 +37,9 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    install_requires=["Django>=3.2", "requests>=2.21.0"],
+    install_requires=["Django>=3.2", "requests>=2.26.0"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,9 @@ args_are_paths = false
 skip_missing_interpreters = true
 envlist = 
     py3.9-flake8
-    {py3.9,py3.10}-django32
-    {py3.9,py3.10}-django40
-    {py3.9,py3.10,py3.11}-django42
-    {py3.10,py3.11}-django50
+    py{3.9,3.10}-django32
+    py{3.9,3.10,3.11}-django42
+    py{3.10,3.11}-django{51,52}
 
 [testenv]
 usedevelop = true
@@ -15,18 +14,18 @@ allowlist_externals = ./runtests.py
 commands = ./runtests.py
 deps =
     django32: Django>=3.2,<4.0
-    django40: Django>=4.0,<4.1
-    django42: Django>=4.2,<4.3
-    django50: Django>=5.0,<5.1
+    django42: Django>=4.2,<5.0
+    django51: Django>=5.1,<5.2
+    django52: Django>=5.2,<6.0
 
     nose==1.3.7
     mock==4.0.3
     responses==0.15.0
     requests==2.26.0
 basepython =
-    py3.11: python3.11
-    py3.10: python3.10
     py3.9: python3.9
+    py3.10: python3.10
+    py3.11: python3.11
 
 [testenv:py3.9-flake8]
 deps = flake8 

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,10 @@ args_are_paths = false
 skip_missing_interpreters = true
 envlist = 
     py3.9-flake8
-    {py3.7,py3.8,py3.9}-django22
-    {py3.7,py3.8,py3.9,py3.10}-django32
-    {py3.8,py3.9,py3.10}-django40
+    {py3.9,py3.10}-django32
+    {py3.9,py3.10}-django40
+    {py3.9,py3.10,py3.11}-django42
+    {py3.10,py3.11}-django50
 
 [testenv]
 usedevelop = true
@@ -13,19 +14,19 @@ pip_pre = true
 allowlist_externals = ./runtests.py
 commands = ./runtests.py
 deps =
-    django22: Django>=2.2,<2.3
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
+    django42: Django>=4.2,<4.3
+    django50: Django>=5.0,<5.1
 
     nose==1.3.7
     mock==4.0.3
     responses==0.15.0
     requests==2.26.0
 basepython =
+    py3.11: python3.11
     py3.10: python3.10
     py3.9: python3.9
-    py3.8: python3.8
-    py3.7: python3.7
 
 [testenv:py3.9-flake8]
 deps = flake8 


### PR DESCRIPTION
Adding newer versions and removing non-LTS branches, now running tests on Python 3.9–3.11 and Django 3.2, 4.2 and 5.1–5.2 ✅

_(To support Python 3.12 a refactor away from imp, therefore replacing nose and mock with current functionality and/or moving to pytest, would be the next step.)_